### PR TITLE
Security: Fix path traversal, XSS, ReDoS, and qs DoS vulnerabilities

### DIFF
--- a/customize.dist/loading.js
+++ b/customize.dist/loading.js
@@ -13,21 +13,29 @@ define([
     var elem = document.createElement('div');
     elem.setAttribute('id', 'cp-loading');
 
-    elem.innerHTML = [
-        '<div class="cp-loading-logo">',
-            '<img class="cp-loading-cryptofist" src="/api/logo?' + urlArgs + '" alt="" aria-hidden="true">',
+    var logo = document.createElement('div');
+    logo.className = 'cp-loading-logo';
+    var img = document.createElement('img');
+    img.className = 'cp-loading-cryptofist';
+    img.setAttribute('src', '/api/logo?' + encodeURI(urlArgs));
+    img.setAttribute('alt', '');
+    img.setAttribute('aria-hidden', 'true');
+    logo.appendChild(img);
+    elem.appendChild(logo);
+
+    var container = document.createElement('div');
+    container.className = 'cp-loading-container';
+    container.innerHTML = [
+        '<div class="cp-loading-spinner-container">',
+            '<span class="cp-spinner"></span>',
         '</div>',
-        '<div class="cp-loading-container">',
-            '<div class="cp-loading-spinner-container">',
-                '<span class="cp-spinner"></span>',
-            '</div>',
-            '<div class="cp-loading-progress" aria-hidden="true" role="presentation">',
-                '<div class="cp-loading-progress-list"></div>',
-                '<div class="cp-loading-progress-container"></div>',
-            '</div>',
-            '<p id="cp-loading-message"></p>',
-        '</div>'
+        '<div class="cp-loading-progress" aria-hidden="true" role="presentation">',
+            '<div class="cp-loading-progress-list"></div>',
+            '<div class="cp-loading-progress-container"></div>',
+        '</div>',
+        '<p id="cp-loading-message"></p>',
     ].join('');
+    elem.appendChild(container);
     var built = false;
 
     var types = ['less', 'drive', 'migrate', 'sf', 'team', 'pad', 'end']; // Msg.loading_state_0, loading_state_1, loading_state_2, loading_state_3, loading_state_4, loading_state_5

--- a/lib/http-worker.js
+++ b/lib/http-worker.js
@@ -313,7 +313,7 @@ app.use(cookieParser());
 if (!Env.logFeedback) { return; }
 
 const logFeedback = function (url) {
-    url.replace(/\?(.*?)=/, function (all, fb) {
+    url.replace(/\?([^=]*)=/, function (all, fb) {
         Log.feedback(fb, '');
     });
 };
@@ -943,7 +943,7 @@ app.post('/api/auth', authRateLimiter, function (req, res, next) {
 
 
 app.use(function (req, res /*, next */) {
-    if (/^(\/favicon\.ico\/|.*\.js\.map|.*\/translations\/.*\.json)/.test(req.url)) {
+    if (/^\/favicon\.ico\//.test(req.url) || /\.js\.map$/.test(req.url) || /\/translations\/[^/]+\.json$/.test(req.url)) {
         // ignore common 404s
     } else {
         Log.info('HTTP_404', req.url);

--- a/lib/storage/challenge.js
+++ b/lib/storage/challenge.js
@@ -23,6 +23,7 @@ const Challenge = module.exports;
 
 const pathFromId = function (Env, id) {
     if (!id || typeof(id) !== 'string') { return void console.error('CHALLENGE_BAD_ID', id); }
+    if (/[/\\]|\.\./.test(id)) { return void console.error('CHALLENGE_BAD_ID', id); }
     return Path.join(Env.paths.base, "challenges", id.slice(0, 2), id);
 };
 

--- a/lib/storage/invite.js
+++ b/lib/storage/invite.js
@@ -18,6 +18,7 @@ const Invite = module.exports;
 
 const pathFromId = function (Env, id) {
     if (!id || typeof(id) !== 'string') { return void console.error('INVITE_BAD_ID', id); }
+    if (/[/\\]|\.\./.test(id)) { return void console.error('INVITE_BAD_ID', id); }
     return Path.join(Env.paths.base, "invitations", id.slice(0, 2), id);
 };
 

--- a/lib/storage/moderator.js
+++ b/lib/storage/moderator.js
@@ -15,6 +15,7 @@ const Moderator = module.exports;
 
 const pathFromId = function (Env, id) {
     if (!id || typeof(id) !== 'string') { return void console.error('KNWONUSER_BAD_ID', id); }
+    if (/[/\\]|\.\./.test(id)) { return void console.error('KNWONUSER_BAD_ID', id); }
     return Path.join(Env.paths.base, "support", id.slice(0, 2), id);
 };
 

--- a/lib/storage/user.js
+++ b/lib/storage/user.js
@@ -15,6 +15,7 @@ const User = module.exports;
 
 const pathFromId = function (Env, id) {
     if (!id || typeof(id) !== 'string') { return void console.error('KNWONUSER_BAD_ID', id); }
+    if (/[/\\]|\.\./.test(id)) { return void console.error('KNWONUSER_BAD_ID', id); }
     return Path.join(Env.paths.base, "users", id.slice(0, 2), id);
 };
 

--- a/package-lock.json
+++ b/package-lock.json
@@ -131,6 +131,7 @@
         }
       ],
       "license": "MIT",
+      "peer": true,
       "engines": {
         "node": ">=18"
       },
@@ -154,6 +155,7 @@
         }
       ],
       "license": "MIT",
+      "peer": true,
       "engines": {
         "node": ">=18"
       }
@@ -1225,6 +1227,7 @@
       "integrity": "sha512-NZyJarBfL7nWwIq+FDL6Zp/yHEhePMNnnJ0y3qfieCrmNvYct8uvtiV41UvlSe6apAfk0fY1FbWx+NwfmpvtTg==",
       "dev": true,
       "license": "MIT",
+      "peer": true,
       "bin": {
         "acorn": "bin/acorn"
       },
@@ -1930,6 +1933,7 @@
         }
       ],
       "license": "MIT",
+      "peer": true,
       "dependencies": {
         "caniuse-lite": "^1.0.30001718",
         "electron-to-chromium": "^1.5.160",
@@ -2857,6 +2861,7 @@
       "integrity": "sha512-GsGizj2Y1rCWDu6XoEekL3RLilp0voSePurjZIkxL3wlm5o5EC9VpgaP7lrCvjnkuLvzFBQWB3vWB3K5KQTveQ==",
       "dev": true,
       "license": "MIT",
+      "peer": true,
       "dependencies": {
         "@eslint-community/eslint-utils": "^4.2.0",
         "@eslint-community/regexpp": "^4.12.1",
@@ -4206,7 +4211,8 @@
       "version": "3.6.0",
       "resolved": "https://registry.npmjs.org/jquery/-/jquery-3.6.0.tgz",
       "integrity": "sha512-JVzAR/AjBvVt2BmYhxRCSYysDsPcssdmTFnzyLEts9qNwmjmu4JTAMYubEfwVOSwpQ1I1sKKFcxhZCI2buerfw==",
-      "license": "MIT"
+      "license": "MIT",
+      "peer": true
     },
     "node_modules/js-tokens": {
       "version": "4.0.0",
@@ -4844,6 +4850,7 @@
       "resolved": "https://registry.npmjs.org/minilog/-/minilog-2.1.0.tgz",
       "integrity": "sha512-UPg2RLmS2JteQ8bn5xA69skwi7evHYcHgRULQIGnNsuXheOHUsFyWitMkqpa3Q9ezSpbDC7vaYKxYCLryCV4og==",
       "license": "MIT",
+      "peer": true,
       "dependencies": {
         "microee": "0.0.2"
       }
@@ -5356,6 +5363,7 @@
       "resolved": "https://registry.npmjs.org/pg/-/pg-8.16.3.tgz",
       "integrity": "sha512-enxc1h0jA/aq5oSDMvqyW3q89ra6XIIDZgCX9vkMrnz5DFTw/Ny3Li2lFQ+pt3L6MCgm/5o2o8HW9hiJji+xvw==",
       "license": "MIT",
+      "peer": true,
       "dependencies": {
         "pg-connection-string": "^2.9.1",
         "pg-pool": "^3.10.1",
@@ -5453,6 +5461,7 @@
       "integrity": "sha512-M7BAV6Rlcy5u+m6oPhAPFgJTzAioX/6B0DxyvDlo9l8+T3nLKbrczg2WLUyzd45L8RqfUMyGPzekbMvX2Ldkwg==",
       "dev": true,
       "license": "MIT",
+      "peer": true,
       "engines": {
         "node": ">=12"
       },
@@ -5512,6 +5521,7 @@
         }
       ],
       "license": "MIT",
+      "peer": true,
       "dependencies": {
         "nanoid": "^3.3.11",
         "picocolors": "^1.1.1",
@@ -5574,6 +5584,7 @@
       "integrity": "sha512-8sLjZwK0R+JlxlYcTuVnyT2v+htpdrjDOKuMcOVdYjt52Lh8hWRYpxBPoKx/Zg+bcjc3wx6fmQevMmUztS/ccA==",
       "dev": true,
       "license": "MIT",
+      "peer": true,
       "dependencies": {
         "cssesc": "^3.0.0",
         "util-deprecate": "^1.0.2"
@@ -5873,12 +5884,12 @@
       }
     },
     "node_modules/qs": {
-      "version": "6.13.0",
-      "resolved": "https://registry.npmjs.org/qs/-/qs-6.13.0.tgz",
-      "integrity": "sha512-+38qI9SOr8tfZ4QmJNplMUxqjbe7LKvvZgWdExBOmd+egZTtjLB67Gu0HRX3u/XOq7UU2Nx6nsjvS16Z9uwfpg==",
+      "version": "6.14.1",
+      "resolved": "https://registry.npmjs.org/qs/-/qs-6.14.1.tgz",
+      "integrity": "sha512-4EK3+xJl8Ts67nLYNwqw/dsFVnCf+qR7RgXSK9jEEm9unao3njwMDdmsdvoKBKHzxd7tCYz5e5M+SnMjdtXGQQ==",
       "license": "BSD-3-Clause",
       "dependencies": {
-        "side-channel": "^1.0.6"
+        "side-channel": "^1.1.0"
       },
       "engines": {
         "node": ">=0.6"
@@ -6147,6 +6158,7 @@
       "integrity": "sha512-qHcdEzLCiktQIfwBq420pn2dP+30uzqYxv9ETm91wdt2R9AFcWfjNAmje4NWlnCIQ5RMTzVf0ZyisOKqHR6RwA==",
       "dev": true,
       "license": "MIT",
+      "peer": true,
       "dependencies": {
         "@types/estree": "1.0.8"
       },
@@ -6766,6 +6778,7 @@
         }
       ],
       "license": "MIT",
+      "peer": true,
       "dependencies": {
         "@csstools/css-parser-algorithms": "^3.0.5",
         "@csstools/css-tokenizer": "^3.0.4",
@@ -7309,7 +7322,8 @@
       "resolved": "https://registry.npmjs.org/tslib/-/tslib-2.8.1.tgz",
       "integrity": "sha512-oJFu94HQb+KVduSUQL7wnpmqnfmLsOA/nAh6b6EH0wCEoK0/mPeXU6c3wKDV83MkOuHPRHtSXKKU99IBazS/2w==",
       "dev": true,
-      "license": "0BSD"
+      "license": "0BSD",
+      "peer": true
     },
     "node_modules/tweetnacl": {
       "version": "1.0.3",
@@ -7388,6 +7402,7 @@
       "integrity": "sha512-jl1vZzPDinLr9eUt3J/t7V6FgNEw9QjvBPdysz9KfQDD41fQrC2Y4vKQdiaUpFT4bXlb1RHhLpp8wtm6M5TgSw==",
       "dev": true,
       "license": "Apache-2.0",
+      "peer": true,
       "bin": {
         "tsc": "bin/tsc",
         "tsserver": "bin/tsserver"

--- a/package.json
+++ b/package.json
@@ -92,7 +92,8 @@
     "minimist": "~1.2.3",
     "minimatch": "~3.1.2",
     "ws": "^8.17.1",
-    "jquery": "3.6.0"
+    "jquery": "3.6.0",
+    "qs": ">=6.14.1"
   },
   "scripts": {
     "install:components": "node scripts/copy-components.js",

--- a/www/form/inner.js
+++ b/www/form/inner.js
@@ -918,7 +918,7 @@ define([
             if (totalMax.value) {
                 $total.find('[data-id]').removeClass('cp-poll-best');
                 totalMax.data.forEach(function (k) {
-                    $total.find('[data-id="'+ (k.replace(/"/g, '\\"')) + '"]').addClass('cp-poll-best');
+                    $total.find('[data-id]').filter(function() { return $(this).attr('data-id') === k; }).addClass('cp-poll-best');
                 });
             }
         };

--- a/www/pad/comments.js
+++ b/www/pad/comments.js
@@ -117,7 +117,7 @@ define([
             var data = others[id];
             Env.common.mailbox.sendTo("COMMENT_REPLY", {
                 channel: privateData.channel,
-                comment: data.comment.replace(/<[^>]*>/g, ''),
+                comment: Util.stripTags(data.comment),
                 content: data.content
             }, {
                 channel: data.notifications,


### PR DESCRIPTION
## Summary

Addresses open CodeQL and Dependabot security alerts with targeted fixes:

- **Path Traversal** (CodeQL #16, #17) — `pathFromId()` in `user.js`, `invite.js`, `moderator.js`, `challenge.js` allowed `../../` in IDs to read/write arbitrary files. Added traversal guards rejecting `/`, `\`, and `..` in IDs.
- **XSS in loading.js** (CodeQL #15) — `urlArgs` from URL query string was injected directly into `innerHTML` via img src, allowing attribute injection. Replaced with DOM API + `encodeURI()`.
- **ReDoS** (CodeQL #39, #40) — Backtracking-prone regex in 404 handler and lazy `.*?` in feedback logger. Split into simple non-backtracking patterns and negated character class.
- **Incomplete HTML stripping** (CodeQL #28) — `comments.js` used `/<[^>]*>/g` regex. Replaced with `Util.stripTags()` (DOMParser-based).
- **jQuery selector injection** (CodeQL #22) — `form/inner.js` interpolated user data into jQuery selector. Replaced with `.filter()` callback.
- **qs DoS** (Dependabot CVE-2025-15284) — `qs@6.13.0` arrayLimit bypass via bracket notation. Added npm override for `qs>=6.14.1`.

### Alerts NOT addressed (false positives / vendored libs):

| Alert | Status | Reason |
|-------|--------|--------|
| #8-#13 notify.js | False positive | `setAttribute('href')` on favicon links with hardcoded paths |
| #32 http-worker.js :705 | False positive | Internal cache cleanup function, not user-controlled dispatch |
| #33 frame.js :97 | False positive | Internal listener dispatch with origin validation |
| #27 assert/main.js | Won't fix | Test file, not production code |
| #2 nextcloud/main.js | Won't fix | Integration test file, localStorage by design |
| #3,#14,#23-#26 mermaid | Vendored | Third-party minified lib |
| #19-#21 pdfjs | Vendored | Third-party minified lib |
| #35 asciidoc | Vendored | Third-party minified lib |
| #9 toggle-array | Won't fix | Transitive dep of prompt-confirm (CLI only, not runtime) |

## Test plan

- [ ] Verify CryptPad loads without errors (loading screen renders correctly)
- [ ] Verify pad comments still send notification text (Util.stripTags works)
- [ ] Verify poll form "best answer" highlighting works
- [ ] Verify feedback logging still functions (check server logs)
- [ ] Verify 404 handler still suppresses common 404 log noise
- [ ] Verify invite/user/moderator storage operations work with valid IDs
- [ ] Confirm `npm ls qs` shows 6.14.1

🤖 Generated with [Claude Code](https://claude.com/claude-code)