### PR TITLE
Fix deploy pipeline: git safe.directory ownership check

### DIFF
--- a/.github/workflows/deploy.yml
+++ b/.github/workflows/deploy.yml
@@ -23,6 +23,7 @@ jobs:
             set -e
             cd /opt/cryptpad
             echo "[$(date)] Starting deployment from GitHub Actions..."
+            git config --global --add safe.directory /opt/cryptpad
             git pull origin main
             docker compose build
             docker compose up -d


### PR DESCRIPTION
## Summary

- **Root cause**: The production deploy workflow fails at `git pull origin main` because Git 2.35.2+ rejects operations on repositories where the directory owner doesn't match the current user (CVE-2022-24765 fix). The workflow SSHes in as `root` but `/opt/cryptpad` is owned by a different user.
- **Fix**: Adds `git config --global --add safe.directory /opt/cryptpad` before `git pull` in the deploy script, telling Git to trust the `/opt/cryptpad` directory regardless of ownership.
- **Impact**: All 5 most recent deploy runs on `main` have failed with this error. This fix unblocks production deployments.

### Error from CI logs
```
fatal: detected dubious ownership in repository at '/opt/cryptpad'
To add an exception for this directory, call:
    git config --global --add safe.directory /opt/cryptpad
Process exited with status 128
```

## CodeQL alerts noted (not addressed in this PR)

There are 24 open CodeQL alerts (all high/medium severity) on this repo, including path injection, XSS, ReDoS, and missing rate limiting findings. Most are in vendored libraries (mermaid, pdfjs) but some are in core code (`lib/http-worker.js`, `lib/storage/basic.js`, `src/common/notify.js`). These should be triaged separately.

## Test plan

- [ ] Merge this PR and verify the "Deploy to Production" workflow succeeds on `main`
- [ ] Verify CryptPad instance at 68.183.87.193 is running after deploy completes
- [ ] Optionally: consider a longer-term fix of `chown`ing `/opt/cryptpad` to `root` on the VPS, or running the deploy as the owning user instead

🤖 Generated with [Claude Code](https://claude.com/claude-code)