### PR TITLE
Harden CodeQL hotspots and update qs to 6.14.2

### DIFF
--- a/lib/http-worker.js
+++ b/lib/http-worker.js
@@ -313,9 +313,17 @@ app.use(cookieParser());
 if (!Env.logFeedback) { return; }
 
 const logFeedback = function (url) {
-    url.replace(/\?([^=]*)=/, function (all, fb) {
-        Log.feedback(fb, '');
-    });
+    if (typeof(url) !== 'string' || url.length > 2048) { return; }
+    var qIndex = url.indexOf('?');
+    if (qIndex < 0) { return; }
+    try {
+        var params = new URLSearchParams(url.slice(qIndex + 1));
+        var first = params.keys().next();
+        if (first.done || typeof(first.value) !== 'string' || first.value.length > 128) { return; }
+        Log.feedback(first.value, '');
+    } catch (err) {
+        return;
+    }
 };
 
 app.head(/^\/common\/feedback\.html/, function (req, res, next) {
@@ -673,10 +681,10 @@ var cacheString = function () {
 };
 
 var makeRouteCache = function (template, cacheName) {
-    var cleanUp = {};
+    var cleanUp = Object.create(null);
 
     return function (req, res) {
-        var cache = Env[cacheName] = Env[cacheName] || {};
+        var cache = Env[cacheName] = Env[cacheName] || Object.create(null);
         var host = req.headers.host.replace(/\:[0-9]+/, '');
         res.setHeader('Content-Type', 'text/javascript');
         // don't cache anything if you're in dev mode
@@ -689,7 +697,7 @@ var makeRouteCache = function (template, cacheName) {
         // FIXME mutable
         // we must be able to clear the cache when updating any mutable key
         // if there's nothing cached for that key...
-        if (!cache[cacheKey]) {
+        if (!Object.prototype.hasOwnProperty.call(cache, cacheKey)) {
             // generate the response and cache it in memory
             cache[cacheKey] = template(host);
             // and create a function to conditionally evict cache entries
@@ -701,8 +709,9 @@ var makeRouteCache = function (template, cacheName) {
         }
 
         // successive calls to this function
-        if (typeof (cleanUp[cacheKey]) === "function") {
-            cleanUp[cacheKey]();
+        var cleanupFn = Object.prototype.hasOwnProperty.call(cleanUp, cacheKey) && cleanUp[cacheKey];
+        if (typeof (cleanupFn) === "function") {
+            cleanupFn();
         }
         return void res.send(cache[cacheKey]);
     };

--- a/package-lock.json
+++ b/package-lock.json
@@ -5876,9 +5876,9 @@
       }
     },
     "node_modules/qs": {
-      "version": "6.14.1",
-      "resolved": "https://registry.npmjs.org/qs/-/qs-6.14.1.tgz",
-      "integrity": "sha512-4EK3+xJl8Ts67nLYNwqw/dsFVnCf+qR7RgXSK9jEEm9unao3njwMDdmsdvoKBKHzxd7tCYz5e5M+SnMjdtXGQQ==",
+      "version": "6.14.2",
+      "resolved": "https://registry.npmjs.org/qs/-/qs-6.14.2.tgz",
+      "integrity": "sha512-V/yCWTTF7VJ9hIh18Ugr2zhJMP01MY7c5kh4J870L7imm6/DIzBsNLTXzMwUA3yZ5b/KBqLx8Kp3uRvd7xSe3Q==",
       "license": "BSD-3-Clause",
       "dependencies": {
         "side-channel": "^1.1.0"

--- a/package.json
+++ b/package.json
@@ -93,7 +93,7 @@
     "minimatch": "~3.1.2",
     "ws": "^8.17.1",
     "jquery": "3.6.0",
-    "qs": ">=6.14.1"
+    "qs": "6.14.2"
   },
   "scripts": {
     "install:components": "node scripts/copy-components.js",


### PR DESCRIPTION
## Summary\nThis PR addresses three open high-severity CodeQL alerts and one open Dependabot alert.\n\n## Fixes\n- CodeQL #81 (lib/http-worker.js):\n  - Replaced regex-based feedback query extraction with bounded parsing via URLSearchParams.\n  - Added basic size guards to avoid expensive parsing on oversized input.\n\n- CodeQL #32 (lib/http-worker.js):\n  - Hardened dynamic cleanup dispatch in route-cache logic by using null-prototype maps and explicit own-property/function checks before invocation.\n\n- CodeQL #33 (www/assert/frame/frame.js):\n  - Hardened dynamic listener dispatch by using null-prototype maps, guarded JSON parsing, UID normalization, and own-property/function checks before callback invocation.\n\n- Dependabot #13 (qs arrayLimit bypass):\n  - Updated qs override in package.json to 6.14.2 and refreshed package-lock.json.\n\n## Validation\n- 
px eslint lib/http-worker.js www/assert/frame/frame.js\n- 
pm ls qs --all (shows qs@6.14.2)\n\n## Notes\n- This PR intentionally does not include unrelated local modifications in other files.

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Low Risk**
> Small, targeted security hardening and a patch dependency bump; primary risk is subtle behavior changes in feedback parsing, cache eviction, or iframe RPC callbacks if edge-case inputs relied on previous permissiveness.
> 
> **Overview**
> Hardens several CodeQL hotspots by tightening parsing and dynamic dispatch paths in both the HTTP worker and iframe RPC code.
> 
> In `lib/http-worker.js`, feedback logging now uses bounded `URLSearchParams` parsing (with type/size guards) and the route-cache maps use null-prototype objects plus explicit own-property/function checks before caching or invoking cleanup callbacks.
> 
> In `www/assert/frame/frame.js`, message handling now guards JSON parsing, normalizes/validates `_uid`, and uses null-prototype maps with own-property checks before clearing timeouts or invoking listeners. Separately, `qs` is pinned/updated to `6.14.2` via `package.json` overrides and `package-lock.json`.
> 
> <sup>Written by [Cursor Bugbot](https://cursor.com/dashboard?tab=bugbot) for commit 60c45213b59c1adee345d147266faacfb786bc56. This will update automatically on new commits. Configure [here](https://cursor.com/dashboard?tab=bugbot).</sup>
<!-- /CURSOR_SUMMARY -->