### PR TITLE
Address remaining first-party code scanning alerts

### DIFF
--- a/lib/http-worker.js
+++ b/lib/http-worker.js
@@ -681,10 +681,11 @@ var cacheString = function () {
 };
 
 var makeRouteCache = function (template, cacheName) {
-    var cleanUp = Object.create(null);
+    var cleanUp = new Map();
 
     return function (req, res) {
-        var cache = Env[cacheName] = Env[cacheName] || Object.create(null);
+        var existingCache = Env[cacheName];
+        var cache = Env[cacheName] = existingCache instanceof Map ? existingCache : new Map();
         var host = req.headers.host.replace(/\:[0-9]+/, '');
         res.setHeader('Content-Type', 'text/javascript');
         // don't cache anything if you're in dev mode
@@ -697,23 +698,23 @@ var makeRouteCache = function (template, cacheName) {
         // FIXME mutable
         // we must be able to clear the cache when updating any mutable key
         // if there's nothing cached for that key...
-        if (!Object.prototype.hasOwnProperty.call(cache, cacheKey)) {
+        if (!cache.has(cacheKey)) {
             // generate the response and cache it in memory
-            cache[cacheKey] = template(host);
+            cache.set(cacheKey, template(host));
             // and create a function to conditionally evict cache entries
             // which have not been accessed in the last 20 seconds
-            cleanUp[cacheKey] = Util.throttle(function () {
-                delete cleanUp[cacheKey];
-                delete cache[cacheKey];
-            }, 20000);
+            cleanUp.set(cacheKey, Util.throttle(function () {
+                cleanUp.delete(cacheKey);
+                cache.delete(cacheKey);
+            }, 20000));
         }
 
         // successive calls to this function
-        var cleanupFn = Object.prototype.hasOwnProperty.call(cleanUp, cacheKey) && cleanUp[cacheKey];
+        var cleanupFn = cleanUp.get(cacheKey);
         if (typeof (cleanupFn) === "function") {
             cleanupFn();
         }
-        return void res.send(cache[cacheKey]);
+        return void res.send(cache.get(cacheKey));
     };
 };
 

--- a/lib/storage/basic.js
+++ b/lib/storage/basic.js
@@ -34,24 +34,39 @@ var pathError = (cb) => {
     });
 };
 
+var isPathInside = function (candidate, root) {
+    if (typeof(candidate) !== 'string' || typeof(root) !== 'string') { return false; }
+    var resolvedCandidate = Path.resolve(candidate);
+    var resolvedRoot = Path.resolve(root);
+    if (resolvedCandidate === resolvedRoot) { return true; }
+    return resolvedCandidate.indexOf(resolvedRoot + Path.sep) === 0;
+};
+
+var isValidStoragePath = function (Env, path) {
+    if (!Env || !Env.paths || typeof(path) !== 'string') { return false; }
+    var base = Env.paths.base;
+    var archive = Env.paths.archive;
+    return isPathInside(path, base) || isPathInside(path, archive);
+};
+
 Basic.read = function (Env, path, cb) {
-    if (!path) { return void pathError(cb); }
+    if (!path || !isValidStoragePath(Env, path)) { return void pathError(cb); }
     Fs.readFile(path, 'utf8', (err, content) => {
         if (err) { return void cb(err); }
         cb(void 0, content);
     });
 };
 Basic.readDir = function (Env, path, cb) {
-    if (!path) { return void pathError(cb); }
+    if (!path || !isValidStoragePath(Env, path)) { return void pathError(cb); }
     Fs.readdir(path, cb);
 };
 Basic.readDirSync = function (Env, path) {
-    if (!path) { return []; }
+    if (!path || !isValidStoragePath(Env, path)) { return []; }
     return Fs.readdirSync(path);
 };
 
 Basic.write = function (Env, path, data, cb) {
-    if (!path) { return void pathError(cb); }
+    if (!path || !isValidStoragePath(Env, path)) { return void pathError(cb); }
     var dirpath = Path.dirname(path);
     Fs.mkdir(dirpath, { recursive: true }, function (err) {
         if (err) { return void cb(err); }
@@ -67,15 +82,18 @@ Basic.write = function (Env, path, data, cb) {
 // Login blocks could probably be implemented with this module if these methods were supported.
 // --Aaron
 Basic.delete = function (Env, path, cb) {
-    if (!path) { return void pathError(cb); }
+    if (!path || !isValidStoragePath(Env, path)) { return void pathError(cb); }
     Fs.rm(path, cb);
 };
 Basic.deleteDir = function (Env, path, cb) {
-    if (!path) { return void pathError(cb); }
+    if (!path || !isValidStoragePath(Env, path)) { return void pathError(cb); }
     Fs.rm(path, { recursive: true, force: true }, cb);
 };
 
 Basic.archive = function (Env, path, archivePath, cb) {
+    if (!isValidStoragePath(Env, path) || !isValidStoragePath(Env, archivePath)) {
+        return void pathError(cb);
+    }
     Fse.move(path, archivePath, {
         overwrite: true,
     }, (err) => {
@@ -83,6 +101,9 @@ Basic.archive = function (Env, path, archivePath, cb) {
     });
 };
 Basic.restore = function (Env, archivePath, path, cb) {
+    if (!isValidStoragePath(Env, archivePath) || !isValidStoragePath(Env, path)) {
+        return void pathError(cb);
+    }
     Fse.move(archivePath, path, {
         //overwrite: true,
     }, (err) => {

--- a/src/common/notify.js
+++ b/src/common/notify.js
@@ -25,6 +25,19 @@ const factory = (ApiConfig = {}) => {
     var DEFAULT_ALT_ICO = '/customize/favicon/alt-favicon' + suffix + '.ico?' + ApiConfig.requireConf.urlArgs;
 
     var document = window.document;
+    var sanitizeFaviconUrl = function (candidate, fallback) {
+        if (typeof(candidate) !== 'string') { return fallback; }
+        var trimmed = candidate.trim();
+        if (!trimmed) { return fallback; }
+        try {
+            var parsed = new URL(trimmed, window.location.origin);
+            var allowedProtocol = parsed.protocol === 'http:' || parsed.protocol === 'https:';
+            if (!allowedProtocol) { return fallback; }
+            return parsed.href;
+        } catch (err) {
+            return fallback;
+        }
+    };
 
     var isSupported = Module.isSupported = function () {
         return typeof(window.Notification) === 'function' && window.isSecureContext;
@@ -47,7 +60,8 @@ const factory = (ApiConfig = {}) => {
     var create = Module.create = function (msg, title, icon) {
         if (document && !icon) {
             var favicon = document.getElementById('favicon');
-            icon = favicon.getAttribute('data-main-favicon') || DEFAULT_ALT;
+            icon = favicon && favicon.getAttribute('data-main-favicon');
+            icon = sanitizeFaviconUrl(icon, DEFAULT_ALT);
         } else if (!icon) {
             icon = DEFAULT_ALT;
         }
@@ -137,13 +151,13 @@ const factory = (ApiConfig = {}) => {
         var altIco = DEFAULT_ALT_ICO;
 
         if (favicon) {
-            main = favicon.getAttribute('data-main-favicon') || DEFAULT_MAIN;
-            alt = favicon.getAttribute('data-alt-favicon') || DEFAULT_ALT;
+            main = sanitizeFaviconUrl(favicon.getAttribute('data-main-favicon'), DEFAULT_MAIN);
+            alt = sanitizeFaviconUrl(favicon.getAttribute('data-alt-favicon'), DEFAULT_ALT);
             favicon.setAttribute('href', main);
         }
         if (faviconIco) {
-            mainIco = faviconIco.getAttribute('data-main-favicon') || DEFAULT_MAIN_ICO;
-            altIco = faviconIco.getAttribute('data-alt-favicon') || DEFAULT_ALT_ICO;
+            mainIco = sanitizeFaviconUrl(faviconIco.getAttribute('data-main-favicon'), DEFAULT_MAIN_ICO);
+            altIco = sanitizeFaviconUrl(faviconIco.getAttribute('data-alt-favicon'), DEFAULT_ALT_ICO);
             faviconIco.setAttribute('href', mainIco);
         }
 

--- a/www/assert/frame/frame.js
+++ b/www/assert/frame/frame.js
@@ -45,8 +45,8 @@
         var frame = {};
         frame.id = uid();
 
-        var listeners = Object.create(null);
-        var timeouts = Object.create(null);
+        var listeners = new Map();
+        var timeouts = new Map();
 
         timeout = timeout || 5000;
 
@@ -96,14 +96,14 @@
                 return;
             }
 
-            if (Object.prototype.hasOwnProperty.call(timeouts, uid)) {
-                window.clearTimeout(timeouts[uid]);
-                delete timeouts[uid];
+            if (timeouts.has(uid)) {
+                window.clearTimeout(timeouts.get(uid));
+                timeouts.delete(uid);
             }
-            var listener = Object.prototype.hasOwnProperty.call(listeners, uid) && listeners[uid];
+            var listener = listeners.get(uid);
             if (typeof(listener) === 'function') {
                 listener(error, data, e);
-                delete listeners[uid];
+                listeners.delete(uid);
             }
         };
         window.addEventListener('message', _listener);
@@ -131,12 +131,12 @@
 
             if (typeof(cb) === 'function') {
                 //console.log("setting callback!");
-                listeners[id] = cb;
+                listeners.set(id, cb);
                 //console.log("setting timeout of %sms", timeout);
-                timeouts[id] = window.setTimeout(function () {
+                timeouts.set(id, window.setTimeout(function () {
                     // when the callback is executed it will clear this timeout
                     cb('[TimeoutError] request timed out after ' + timeout + 'ms');
-                }, timeout);
+                }, timeout));
             } else {
                 console.log(typeof(cb));
             }

--- a/www/nextcloud/main.js
+++ b/www/nextcloud/main.js
@@ -15,9 +15,8 @@ define([
         // It can be used to embed another cryptpad instance using the new API
 
         console.log(Api);
-        var permaKey = localStorage.CP_test_API_key || '/2/integration/edit/X3RlrgR2JhA0rI+PJ3rXufsQ/';
-        var key = window.location.hash ? window.location.hash.slice(1)
-                                       : permaKey;
+        var defaultKey = '/2/integration/edit/X3RlrgR2JhA0rI+PJ3rXufsQ/';
+        var key = window.location.hash ? window.location.hash.slice(1) : defaultKey;
         window.location.hash = key;
 
 // Test doc
@@ -28,9 +27,6 @@ var blob = new Blob([mystring], {
 var docUrl = URL.createObjectURL(blob);
 console.warn(docUrl);
 
-localStorage.CP_test_API_key = key;
-
-
         var onSave = function (_blob, cb) {
             console.log('APP ONSAVE', _blob);
             docUrl = URL.createObjectURL(_blob);
@@ -38,22 +34,9 @@ localStorage.CP_test_API_key = key;
             if (typeof (cb) === "function") { cb(); }
         };
         var onNewKey = function (data, cb) {
-            // setTimeout hack because Firefox doesn't have locks for localStorage
-            setTimeout(function () {
-
             var newKey = data.new;
-            var oldKey = data.old;
-            var stored = localStorage.CP_test_API_key;
-            if (stored !== oldKey) {
-                console.error(`Deprecated old key "${oldKey}", can't store the new one "${newKey}"`);
-                window.location.hash = stored;
-                return void cb(stored);
-            }
-            localStorage.CP_test_API_key = newKey;
             window.location.hash = newKey;
             cb(newKey);
-
-            }, Math.floor(Math.random()*300));
         };
 
 


### PR DESCRIPTION
## Summary\nFollow-up security hardening for first-party code after the latest CodeQL refresh.\n\n## Changes\n- lib/storage/basic.js\n  - Added path boundary validation to ensure storage operations stay under Env.paths.base or Env.paths.archive.\n  - Applies to read/write/delete/archive/restore paths.\n\n- lib/http-worker.js\n  - Reworked route-cache internals to use Map for cache/cleanup dispatch instead of dynamic object-indexed invocation.\n\n- www/assert/frame/frame.js\n  - Reworked listener/timeout registries to Map and kept guarded callback dispatch.\n\n- src/common/notify.js\n  - Added favicon URL sanitization helper and applied it before href assignment.\n\n- www/nextcloud/main.js\n  - Removed localStorage persistence of the test API key in the integration demo page.\n\n## Intended alert impact\n- Path injection: #16, #17\n- Unvalidated dynamic method call: #82, #83\n- DOM XSS through DOM text flow in notify path: #8-#13\n- Clear text storage of sensitive info: #2\n\n## Validation\n- 
px eslint lib/storage/basic.js lib/http-worker.js www/assert/frame/frame.js src/common/notify.js www/nextcloud/main.js\n