### PR TITLE
ci: skip deploy on bot submodule-only commits

### DIFF
--- a/.github/workflows/deploy.yml
+++ b/.github/workflows/deploy.yml
@@ -12,6 +12,9 @@ permissions:
 jobs:
   deploy:
     runs-on: ubuntu-latest
+    if: |
+      !contains(github.event.head_commit.message, '[skip ci]') &&
+      github.event.head_commit.author.name != 'open-paws-bot'
     steps:
       - name: Deploy to Droplet
         uses: appleboy/ssh-action@0ff4204d59e8e51228ff73bce53f80d53301dee2 # v1.2.5

--- a/.github/workflows/deploy.yml
+++ b/.github/workflows/deploy.yml
@@ -12,9 +12,13 @@ permissions:
 jobs:
   deploy:
     runs-on: ubuntu-latest
-    if: |
-      !contains(github.event.head_commit.message, '[skip ci]') &&
-      github.event.head_commit.author.name != 'open-paws-bot'
+    if: >
+      github.event_name == 'workflow_dispatch' ||
+      (
+        github.event_name == 'push' &&
+        !contains(github.event.head_commit.message || '', '[skip ci]') &&
+        (github.event.head_commit.author.name || '') != 'open-paws-bot'
+      )
     steps:
       - name: Deploy to Droplet
         uses: appleboy/ssh-action@0ff4204d59e8e51228ff73bce53f80d53301dee2 # v1.2.5


### PR DESCRIPTION
## Summary

- Adds a job-level `if:` condition to the `Deploy to Production` workflow
- Deploy is skipped when `[skip ci]` appears in the commit message
- Deploy is skipped when the commit author is `open-paws-bot`
- Human commits on `main` continue to deploy normally via `workflow_dispatch` or push

## Root cause

CI audit (2026-04-13) found 13+ consecutive deploy failures on 2026-04-12T13:21–15:03. During dispatch waves, `open-paws-bot` makes 6+ submodule-update commits per hour. Each commit triggered `Deploy to Production`, causing deploy storms that overloaded the environment. The `[skip ci]` tag in those commit messages was not preventing the deploy workflow from running.

## Test plan

- [ ] YAML syntax validated (`python3 -c "import yaml; yaml.safe_load(...)"` — passes)
- [ ] Verify: bot submodule commit (author `open-paws-bot`, message contains `[skip ci]`) → deploy job skipped
- [ ] Verify: human commit on `main` → deploy job runs normally
- [ ] Verify: `workflow_dispatch` trigger → deploy job runs (condition only applies to `head_commit` context on push events)

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Chores**
  * Improved deployment automation with enhanced conditional execution rules for more controlled releases. The deployment workflow now intelligently evaluates commit metadata to determine when deployments should proceed, preventing unnecessary automated runs. This provides development teams with greater precision in managing release timing and enables selective deployment execution based on specific conditions.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->