### PR TITLE
docs: comprehensive README and AGENTS.md

### DIFF
--- a/AGENTS.md
+++ b/AGENTS.md
@@ -1,0 +1,189 @@
+# AGENTS.md — cryptpad-project-management
+
+## Summary
+
+This is an end-to-end encrypted project management tool built as a fork of [CryptPad](https://github.com/cryptpad/cryptpad). Open Paws customizations extend the upstream Kanban board application with a ten-dimension strategic scoring system, three-tier security classification (T1/T2/T3), timeline and personal task views, assignee management, dependency tracking, and T3-item redaction on export. All customizations live in `www/kanban/`. Upstream CryptPad handles encryption, real-time collaboration, access control, and all other application types (Docs, Sheets, Whiteboard, etc.) without modification. The server never has access to decryption keys or document content — all cryptographic operations happen client-side using NaCl secretbox.
+
+---
+
+## Status
+
+**🟢 Production** — Active operational tool. Deployed at `https://cryptpaws.openpaws.ai`. Stores Tier 3 data (investigation planning, witness coordination, legal defense notes). Treat all encryption-related changes as security-critical.
+
+**Change implications of this status:**
+- Do not merge features that add server-side content access under any circumstances
+- Upstream sync requires a dedicated review branch and functional verification before merging to main
+- Breaking the export T3 redaction is a data confidentiality incident
+
+---
+
+## Key Files
+
+### Open Paws Customizations (fork-specific)
+
+| File | Purpose |
+|------|---------|
+| `www/kanban/inner.js` | Primary customization layer. Strategic scoring (10 dimensions), security tier filtering, assignee management, Timeline view, My Tasks view, dependency tracking, T3 redaction. ~300 KB — the largest single file in the fork. |
+| `www/kanban/jkanban_cp.js` | CryptPad fork of jKanban board renderer. DST-safe date arithmetic (`parseDateLocal`, `toDayNumber`), relative due-date formatting, Dragula drag-and-drop. |
+| `www/kanban/export.js` | CryptDrive bulk export handler. Strips T3 items before export via `redactT3Items()`. Intentionally self-contained with no imports for reliability in the export pipeline. |
+| `www/kanban/CLAUDE.md` | Kanban-specific development guide. Read before touching `www/kanban/`. |
+| `CLAUDE.md` | Root development guide. Contains the Ten Commandments of CryptPad Development — inviolable rules for preserving E2EE. |
+| `SECURITY_DECISIONS.md` | Security audit log. Documents resolved CVEs, false positives, and accepted risks. |
+| `docker-compose.yml` | Deployment configuration. Domains, ports, volume mounts. |
+| `config/config.example.js` | Server configuration template. |
+| `customize/translations/` | Custom translation overrides. |
+
+### Upstream CryptPad (do not modify without security review)
+
+| File/Directory | Purpose |
+|---|---|
+| `lib/` | Server-side: history keeper, metadata, access control, block storage |
+| `lib/hk-util.js` | History keeper — stores encrypted blobs, validates signatures, never decrypts |
+| `lib/metadata.js` | Access control command handlers (ADD_OWNERS, RESTRICT_ACCESS, etc.) |
+| `lib/crypto.js` | Core encryption: NaCl secretbox, key derivation, signature verification |
+| `www/common/sframe-chainpad-netflux-outer.js` | Encryption layer: encrypts outgoing, decrypts incoming |
+| `www/common/sframe-app-framework.js` | App framework used by all editors — wraps encryption transparently |
+| `src/common/common-hash.js` | URL hash parsing, key derivation from URL fragments |
+| `server.js` | Entry point |
+
+---
+
+## Deploy Commands
+
+```bash
+# Production (Docker Compose)
+docker compose up -d
+
+# View logs
+docker compose logs -f cryptpad
+
+# Restart after config change
+docker compose restart cryptpad
+
+# Development (local Node.js)
+npm install
+npm run install:components
+npm run dev         # DEV=1 node server.js
+
+# Lint
+npm run lint
+
+# Build assets
+npm run build
+```
+
+**Required environment variables (via docker-compose.yml):**
+
+| Variable | Value |
+|----------|-------|
+| `CPAD_MAIN_DOMAIN` | `https://cryptpaws.openpaws.ai` |
+| `CPAD_SANDBOX_DOMAIN` | `https://cryptbox.openpaws.ai` |
+| `CPAD_CONF` | `/cryptpad/config/config.js` |
+
+**Ports (host → container):**
+
+| Host | Container | Service |
+|------|-----------|---------|
+| 3002 | 3000 | Main application (HTTP) |
+| 3001 | 3001 | WebSocket |
+| 3005 | 3003 | Sandbox domain |
+
+---
+
+## Architecture Decisions
+
+### Why CryptPad
+
+Animal advocacy organizations face three adversaries: state surveillance via ag-gag statutes and subpoenas, industry infiltration through corporate investigators, and data breaches. CryptPad's zero-knowledge model means the server operator cannot comply with a subpoena for document contents because the server does not have them. No other collaboration tool with real-time multi-user editing provides this guarantee.
+
+### Encryption Model
+
+CryptPad uses NaCl secretbox (XSalsa20-Poly1305) with keys derived from the URL hash fragment. Hash fragments are never sent to servers by browsers. The key hierarchy (from `lib/crypto.js`):
+
+```
+seed (18 bytes base64 from URL)
+  └── hash = Nacl.hash(seed + optional-password)
+        ├── signKey  = hash[0:32]  → Ed25519 keypair (signs metadata commands)
+        ├── cryptKey = hash[32:64] → XSalsa20-Poly1305 (encrypts content)
+        └── chanId   = derive(hash) → identifies the server channel
+```
+
+The server sees channel IDs and encrypted blobs. It validates Ed25519 signatures for access control commands but never decrypts content.
+
+### What Was Customized and Why
+
+The upstream Kanban is a general-purpose board. Open Paws needed:
+
+1. **Strategic prioritization** — campaign work spans many projects; a scoring system surfaces the highest-leverage work. Ten dimensions were chosen to cover scale, depth, longevity, and movement-building value.
+2. **Security tiering** — investigation planning (T3) must never appear in exports or default views due to legal risk. Tier filtering is built into the board, not bolted on later.
+3. **Timeline and personal task views** — coordination across many simultaneous campaigns requires both a project-level Gantt view and a personal task view.
+4. **Dependency tracking** — projects have prerequisites; dependency IDs enable that graph.
+
+All of this is implemented as plaintext JSON manipulation in `inner.js`. The CryptPad framework handles encryption transparently.
+
+### Encryption Domain Sovereignty (2026-03-28)
+
+CryptPad's NaCl secretbox and Matrix's Megolm are structurally incompatible encryption systems. A proxy re-encryption bridge would require a server that holds keys for both — destroying the zero-knowledge property. This decision is settled: all content crossing between CryptPad and other systems must be a deliberate human action at the application layer. No automated bridges.
+
+### SSO Constraint
+
+If SSO is enabled, `forceCpPassword: true` is mandatory. Without it, the SSO provider's session token becomes a de facto decryption key proxy — a server that can decrypt documents exists, which defeats the threat model against subpoena.
+
+---
+
+## Integration Points
+
+| System | Integration | Notes |
+|--------|-------------|-------|
+| NGINX | Reverse proxy | Terminates SSL, proxies to ports 3002/3001/3005 |
+| Let's Encrypt | TLS certificates | Two certificates required (main domain + sandbox domain) |
+| CryptPad upstream | Git fork | Customizations in `www/kanban/` only; sync via `git merge upstream/main` |
+| Matrix | None (intentional) | Keys must never appear in Matrix widget state events; use pinned message links only |
+| Open Paws platform | None (intentional) | CryptPad is encryption-domain sovereign; no automated data extraction |
+
+---
+
+## Safe vs Risky Changes
+
+### Safe
+
+- UI text changes in `customize/translations/`
+- CSS changes in `www/kanban/app-kanban.less`
+- Adding or renaming scoring dimensions in `inner.js` (the `scoringDimensions` array at module level)
+- Adding new filter or sort options that operate on existing item fields
+- Updating `docker-compose.yml` resource limits
+- Dependency updates for non-cryptographic packages when Dependabot flags them
+
+### Requires Care
+
+- Any change to `www/kanban/inner.js` — verify `framework.localChange()` is always the write path
+- Adding new item fields — fields not in the content object will not be encrypted and synced
+- Upstream CryptPad sync — always merge to a review branch, check the kanban diff, verify T3 redaction
+
+### High Risk (security review required before merge)
+
+- Any change to `lib/crypto.js`, `lib/hk-util.js`, `lib/metadata.js`
+- Any change to `www/common/sframe-chainpad-netflux-outer.js` or `sframe-app-framework.js`
+- Any change to `server.js` that adds new HTTP endpoints
+- Any change to `www/kanban/export.js` — T3 redaction must be verified
+- SSO configuration changes
+- Adding any form of server-side content reading, caching, or logging
+
+### Never Do
+
+- Add a server endpoint that accepts or returns plaintext document content
+- Log encrypted message content on the server (even encrypted blobs should not be logged verbatim)
+- Store encryption keys outside URL hash fragments or user's encrypted drive
+- Reuse nonces in any encryption operation
+- Add a Matrix widget or bridge that would place CryptPad keys in Matrix state events
+
+---
+
+## TODOs
+
+- [ ] Upstream sync review: check for kanban changes in cryptpad/cryptpad since the last merge
+- [ ] Verify `forceCpPassword: true` is set in the deployed SSO config
+- [ ] Add characterization tests for T3 redaction in `export.js` before the next upstream sync
+- [ ] Document the NGINX configuration (SSL termination, CSP headers, two-domain setup) in `docs/`
+- [ ] Evaluate `toggle-array` transitive dependency (CVE-2025-57328, CVSS 2.9) — no fix available; monitor
+- [ ] Consider moving scoring dimensions to a shared config file so `inner.js` and `www/kanban/CLAUDE.md` stay in sync automatically

--- a/readme.md
+++ b/readme.md
@@ -6,106 +6,314 @@ SPDX-License-Identifier: AGPL-3.0-or-later
 
 # Open Paws Project Management
 
-**End-to-end encrypted project management for organizations with high security requirements.**
+> **Status: 🟢 Production** — Active operational tool for Open Paws. Do not add server-side content extraction features. See [Architecture Decisions](#architecture-decisions) for settled constraints.
 
-This is a customized version of [CryptPad](https://cryptpad.org) that transforms the Kanban board into a full-featured project management tool. Built for [Open Paws](https://openpaws.ai) to coordinate animal advocacy work, but useful for any organization that needs secure, collaborative project planning.
+**End-to-end encrypted project management for animal advocacy organizations with high security requirements.**
+
+This is a customized fork of [CryptPad](https://cryptpad.org) that extends the Kanban board into a full-featured project management tool with strategic scoring, security-tiered access, dependency tracking, and multiple views. Built for [Open Paws](https://openpaws.ai) to coordinate advocacy work, but suitable for any organization that needs secure, collaborative project planning.
+
+Part of the [Open Paws ecosystem](https://github.com/Open-Paws).
 
 ---
 
-## What We Built
+## Table of Contents
 
-We've extended CryptPad's Kanban with three integrated views, task management, and a strategic scoring system—all while preserving CryptPad's zero-knowledge encryption.
+- [Why CryptPad](#why-cryptpad)
+- [What This Fork Adds](#what-this-fork-adds)
+- [Privacy and Security Model](#privacy-and-security-model)
+- [Deployment](#deployment)
+- [Configuration Reference](#configuration-reference)
+- [Usage](#usage)
+- [Syncing with Upstream CryptPad](#syncing-with-upstream-cryptpad)
+- [Contributing](#contributing)
+- [License](#license)
+
+---
+
+## Why CryptPad
+
+CryptPad implements **zero-knowledge end-to-end encryption** using NaCl secretbox (XSalsa20-Poly1305). Encryption keys are derived from the URL hash fragment — a browser mechanism that is never sent to the server. This means:
+
+- The server stores only encrypted blobs it cannot read
+- There is no password or key to subpoena from the server operator
+- Investigation planning notes, witness coordination, and legal defense drafts remain private even under hostile legal discovery
+- Advocacy organizations can collaborate on sensitive campaign strategy without operational security risk
+
+CryptPad is AGPL-licensed, audited open-source software maintained by XWiki SAS. Self-hosting removes any third-party data exposure. No other collaboration tool combines this privacy model with real-time multi-user editing.
+
+---
+
+## What This Fork Adds
+
+All customizations are confined to `www/kanban/`. Upstream CryptPad code is unchanged.
 
 ### Three Views
 
-**Pipeline** — Enhanced kanban board with drag-and-drop columns, priority scores displayed on each card, and a compact mode toggle.
+**Pipeline** — Enhanced kanban board with drag-and-drop columns, strategic priority scores on each card, and a compact mode toggle for dense boards.
 
-**My Tasks** — Personal dashboard showing all your tasks across every project. Check off tasks, edit inline, filter by status or due date.
+**My Tasks** — Personal dashboard showing all tasks assigned to you across every project. Check off tasks inline, filter by status or due date, edit without leaving the view.
 
 **Timeline** — Gantt chart view. Drag projects to reschedule, resize bars to change duration. Tasks appear nested under their parent projects.
+
+### Strategic Scoring System
+
+Ten-dimension scoring system for campaign prioritization. Each dimension is scored 0–10; the composite score (average) displays on cards and drives filtering and sorting.
+
+| Key | Dimension | What It Measures |
+|-----|-----------|-----------------|
+| `scale_score` | Scale | Number of animals and advocates affected |
+| `impact_magnitude_score` | Impact Magnitude | Depth of positive change |
+| `longevity_score` | Longevity | Lasting value over time |
+| `multiplication_score` | Multiplication | Enables additional impact |
+| `foundation_score` | Foundation | Creates platform for future work |
+| `agi_readiness_score` | Future-Readiness | Adapts to a changing landscape |
+| `accessibility_score` | Accessibility | Easy for advocates to adopt |
+| `coalition_building_score` | Coalition Building | Strengthens movement unity |
+| `pillar_coverage_score` | Coverage | Impact across advocacy approaches |
+| `build_feasibility_score` | Build Feasibility | Speed and ease of implementation |
+
+### Security Tier Filtering
+
+Projects carry a `security_tier` field (`T1`, `T2`, or `T3`) aligned with the [Open Paws three-tier security model](SECURITY_DECISIONS.md):
+
+| Tier | Data Type | Handling |
+|------|-----------|----------|
+| T1 | Public-facing campaign content | Visible by default; exportable |
+| T2 | Internal strategy, coalition coordination | Visible by default; exportable |
+| T3 | Investigation planning, witness coordination, legal defense notes | Filtered from default views; stripped from all exports |
+
+T3 items are never included in CryptDrive bulk exports. The `export.js` file and `redactT3Items()` in `inner.js` both enforce this independently.
 
 ### Tasks Inside Projects
 
 Each project card can contain sub-tasks:
+
 - Checkbox completion tracking
 - Per-task assignees and due dates
-- Progress indicator on cards (e.g., "3/5 complete")
-- Tasks inherit the project's due date if none set
+- Progress indicator on the card (e.g., "3/5 complete")
+- Tasks inherit the project's due date when none is set
+- Dependency IDs link tasks across projects
 
-### Project Scoring
+### Assignee and Date Management
 
-Nine-dimension scoring system for prioritization:
+- Assign team members to projects and individual tasks
+- Start dates and due dates with urgency indicators
+- DST-safe date arithmetic (`parseDateLocal` / `toDayNumber` in `jkanban_cp.js`)
 
-| Dimension | What it measures |
-|-----------|------------------|
-| Scale | Number of animals/advocates affected |
-| Impact Magnitude | Depth of positive change |
-| Longevity | Lasting value over time |
-| Multiplication | Enables additional impact |
-| Foundation | Creates platform for future work |
-| Accessibility | Easy for advocates to adopt |
-| Coalition Building | Strengthens movement unity |
-| Coverage | Impact across advocacy approaches |
-| Build Feasibility | Speed and ease of implementation |
+### Filtering and Sorting
 
-Each dimension scored 0-10. The composite score (average) displays on cards and enables score-based filtering and sorting.
-
-### Other Features
-
-- **Assignee management** — Assign team members to projects and tasks
-- **Date tracking** — Start dates and due dates with urgency indicators
-- **Filtering** — By assignee, score range, due date preset, completion status
-- **Sorting** — By score, due date, title, or creation date
-- **Real-time collaboration** — Multiple users editing simultaneously
-- **Compact mode** — Hide card details for a cleaner board view
+Filter by assignee, score range, due date preset, completion status, and security tier. Sort by score, due date, title, or creation date.
 
 ---
 
-## Security
+## Privacy and Security Model
 
-All data—including scores, assignees, tasks, and dates—is encrypted in your browser before reaching the server. The server only stores encrypted blobs it cannot read.
+### Zero-Knowledge Architecture
 
-This is CryptPad's standard zero-knowledge model. Our enhancements add no server-side components and make no changes to the encryption layer.
+All data — scores, assignees, tasks, dates, notes — is encrypted in the browser before it reaches the server. The server stores encrypted blobs and cannot read any content.
+
+```
+User edits card (plaintext JSON in browser)
+    ↓
+ChainPad creates a diff patch
+    ↓
+NaCl secretbox encrypts the patch
+    ↓
+Encrypted blob transmitted to server
+    ↓
+Server stores and broadcasts the blob — reads nothing
+    ↓
+Other clients decrypt and render
+```
+
+The encryption key lives in the URL hash fragment. Browsers never send hash fragments to servers. Sharing a document means sharing its URL; access control is cryptographic, not server-side.
+
+### What the Server Can and Cannot See
+
+| The server CAN see | The server CANNOT see |
+|---|---|
+| Channel IDs (32 hex characters) | Document content of any kind |
+| Message timestamps and sizes | User display names in documents |
+| Who is connected (by session ID, not identity) | Search queries or tags |
+| Access-control metadata (owners as public keys) | File names (encrypted in drive metadata) |
+| Metadata command signatures | Encryption keys |
+
+### Security Tiers and Legal Risk
+
+This tool stores Tier 3 data (investigation planning, witness coordination, legal defense notes). The encryption architecture is the primary protection. No feature may add server-side content extraction. SSO integration requires `forceCpPassword: true` so that the server operator's SSO provider cannot derive encryption keys.
+
+Full security analysis: [SECURITY_DECISIONS.md](SECURITY_DECISIONS.md)
+
+### Settled Constraints (2026-03-28 Decisions)
+
+- CryptPad remains sovereign in its encryption domain. No automated content extraction.
+- CryptPad (NaCl secretbox) and Matrix (Megolm) are structurally incompatible. Content crossing between them must be a deliberate human action — no proxy re-encryption bridges.
+- CryptPad keys must never appear in Matrix widget state events. Use the wrapper-page pattern with keys stored in encrypted timeline events.
 
 ---
 
 ## Deployment
 
-### Self-Host with Docker
+### Requirements
 
-CryptPad requires proper infrastructure—it won't work on PaaS platforms like Railway, Vercel, or Heroku due to:
-- Sandboxed cross-origin iframe requirements
+CryptPad requires dedicated infrastructure and will not run correctly on PaaS platforms (Railway, Vercel, Heroku, Render) due to:
+
+- Cross-origin iframe sandboxing requiring two separate domains
 - Persistent WebSocket connections
-- Complex CSP header configuration
-- Two-domain setup (main + sandbox subdomain)
+- Complex Content Security Policy header configuration
+- High file descriptor limits
 
-**Recommended setup:**
-- VPS (2GB RAM, 2 CPU cores minimum)
-- Docker Compose
-- NGINX reverse proxy
-- Let's Encrypt SSL
-- Two DNS A records (main domain + sandbox subdomain)
+**Minimum VPS spec:** 2 GB RAM, 2 CPU cores  
+**Recommended stack:** Docker Compose + NGINX reverse proxy + Let's Encrypt SSL
 
-**Development setup**: Follow CryptPad's [developer guide](https://docs.cryptpad.org/en/dev_guide/setup.html).
+### DNS Setup
+
+You need two DNS A records pointing to your server:
+
+```
+cryptpaws.openpaws.ai   →  <your-server-ip>
+cryptbox.openpaws.ai    →  <your-server-ip>
+```
+
+The main domain serves the application. The sandbox domain isolates untrusted content in a separate origin.
+
+### Docker Compose Deployment
+
+```bash
+# Clone the repo
+git clone https://github.com/Open-Paws/cryptpad-project-management.git
+cd cryptpad-project-management
+
+# Copy the example config
+cp config/config.example.js config/config.js
+
+# Edit config — set httpUnsafeDomain and httpSafeDomain at minimum
+$EDITOR config/config.js
+
+# Start the service
+docker compose up -d
+
+# Check health
+docker compose ps
+curl -f http://localhost:3002/
+```
+
+The `docker-compose.yml` maps:
+- Port 3002 (host) → 3000 (container): main app
+- Port 3001 (host) → 3001 (container): WebSocket
+- Port 3005 (host) → 3003 (container): sandbox
+
+Set up NGINX to proxy these ports to your two domains with SSL termination.
+
+### Volumes
+
+| Volume | Contents |
+|--------|----------|
+| `./data/blob` | Uploaded files (encrypted) |
+| `./data/block` | User login blocks (encrypted) |
+| `./customize` | Custom translations and branding |
+| `./data/data` | Server state, session data |
+| `./data/files` | Document datastore (encrypted) |
+| `./config/config.js` | Server configuration (mounted read-only) |
+
+Back up `./data/` regularly. The datastore contains all encrypted documents.
+
+### Development Setup
+
+Follow the upstream [CryptPad developer guide](https://docs.cryptpad.org/en/dev_guide/setup.html) to run a local instance without Docker. Node.js 18+ is required (see `.nvmrc`).
+
+```bash
+npm install
+npm run install:components
+npm run dev
+```
+
+---
+
+## Configuration Reference
+
+The primary configuration file is `config/config.js` (copied from `config/config.example.js`). Key settings:
+
+| Setting | Description | Example |
+|---------|-------------|---------|
+| `httpUnsafeDomain` | Main application domain | `"https://cryptpaws.openpaws.ai"` |
+| `httpSafeDomain` | Sandbox domain for untrusted content | `"https://cryptbox.openpaws.ai"` |
+| `httpAddress` | Interface to bind (Docker: `0.0.0.0`) | `"0.0.0.0"` |
+| `httpPort` | Application port | `3000` |
+| `websocketPort` | WebSocket port | `3003` |
+| `adminKeys` | Ed25519 public keys for admin panel | `["<key>"]` |
+| `maxWorkers` | Worker thread count (defaults to CPU count - 1) | `4` |
+| `storage` | Storage backend (`"file"` or database) | `"file"` |
+
+SSO is configured separately in `config/sso.example.js`. If SSO is enabled, `forceCpPassword: true` is required to preserve zero-knowledge properties.
 
 ---
 
 ## Usage
 
 1. Create a new Kanban board from the CryptPad drive
-2. Add columns (e.g., Backlog, In Progress, Done)
+2. Add columns (e.g., Backlog, In Progress, Review, Done)
 3. Create project cards in columns
-4. Click a card to edit: add tasks, set scores, assign team members, set dates
-5. Switch views using the toolbar buttons (Pipeline / My Tasks / Timeline)
-6. Use filters and sort options to focus on what matters
+4. Click a card to edit: add tasks, set scores, assign team members, set dates, choose security tier
+5. Switch views using the toolbar: Pipeline / My Tasks / Timeline
+6. Use filters and sort options to focus current work
+7. Use score-based sorting to surface highest-priority campaigns
 
 ---
 
-## Built On
+## Syncing with Upstream CryptPad
 
-This is a fork of [CryptPad](https://github.com/cryptpad/cryptpad), the open-source encrypted collaboration suite developed by [XWiki SAS](https://www.xwiki.com). CryptPad provides Documents, Spreadsheets, Presentations, Polls, Whiteboards, and more—all end-to-end encrypted.
+This fork tracks upstream [cryptpad/cryptpad](https://github.com/cryptpad/cryptpad). All Open Paws customizations live in `www/kanban/` — upstream changes to that directory require careful merge review.
 
-Our modifications are limited to the Kanban application (`www/kanban/`). Everything else is standard CryptPad.
+```bash
+# Add upstream remote (first time only)
+git remote add upstream https://github.com/cryptpad/cryptpad.git
+
+# Fetch upstream changes
+git fetch upstream
+
+# Review what changed in the kanban directory
+git diff main upstream/main -- www/kanban/
+
+# Merge upstream into a branch for review
+git checkout -b upstream-sync
+git merge upstream/main
+
+# Resolve conflicts in www/kanban/ carefully
+# Run the test suite and verify the three views still work
+# Verify T3 redaction still functions in export
+```
+
+**High-risk files for upstream sync:**
+
+| File | Risk |
+|------|------|
+| `www/kanban/inner.js` | All Open Paws features live here — merge conflicts are likely |
+| `www/kanban/jkanban_cp.js` | Date arithmetic and drag-drop customizations |
+| `www/kanban/export.js` | T3 redaction logic — must be verified after every sync |
+| `lib/hk-util.js` | Server-side history keeper — do not change encryption handling |
+
+After any upstream sync, verify:
+
+- [ ] All three views (Pipeline, My Tasks, Timeline) render correctly
+- [ ] Scoring dimensions display and save on cards
+- [ ] T3 items do not appear in exports
+- [ ] Real-time collaboration works between two browser sessions
+- [ ] View-only links cannot write
+
+---
+
+## Contributing
+
+1. Read `CLAUDE.md` before writing any code — it contains the Ten Commandments of CryptPad development that are inviolable for this codebase
+2. Read `www/kanban/CLAUDE.md` for Kanban-specific patterns
+3. Never bypass `framework.localChange()` — it is the only encrypted sync path
+4. Never add server-side content access of any kind
+5. Run `semgrep --config semgrep-no-animal-violence.yaml` on all code and documentation changes
+6. Run `desloppify scan --path .` (minimum score: 85)
+7. Security-sensitive changes (encryption, key derivation, access control) require review before merging
+
+Use movement terminology precisely. No speciesist idioms in code, comments, or commit messages.
 
 ---
 
@@ -113,5 +321,4 @@ Our modifications are limited to the Kanban application (`www/kanban/`). Everyth
 
 GNU Affero General Public License v3.0 or later. See [LICENSE](LICENSE).
 
-[Tor browser]: https://www.torproject.org/download/
-[active attack]: https://en.wikipedia.org/wiki/Attack_(computing)#Types_of_attack
+Upstream CryptPad is developed by [XWiki SAS](https://www.xwiki.com). Open Paws customizations are copyright Open Paws contributors.


### PR DESCRIPTION
## Summary

- **README** (`readme.md`): Rewrites the existing readme with full coverage of why CryptPad was chosen (zero-knowledge E2EE for advocacy orgs under legal threat), all ten scoring dimensions (correcting the existing readme which listed only nine), the three-tier security classification system (T1/T2/T3), Docker Compose deployment with DNS and NGINX requirements, configuration reference, upstream sync procedure with per-file risk guidance, and contributing rules.

- **AGENTS.md** (new file): One-paragraph summary, status badge and change implications, annotated file map distinguishing Open Paws customizations from upstream CryptPad, deploy commands, architecture decisions (why CryptPad, what was customized and why, encryption domain sovereignty, SSO constraint), integration points, safe/risky/never-do change classification, and actionable TODOs.

## Key corrections and additions over the previous readme

- Scoring system has ten dimensions, not nine — added `agi_readiness_score` (Future-Readiness) which was missing
- Security tier filtering (T1/T2/T3) was not documented at all
- T3 redaction on export was not documented
- Dependency tracking was not documented
- DST-safe date arithmetic was not documented
- The upstream sync procedure and per-file merge risk guide are new
- The settled 2026-03-28 architecture decisions (encryption domain sovereignty, Matrix constraint, SSO requirement) are now surfaced for contributors

## Test plan

- [ ] Verify the ten scoring dimension keys in `www/kanban/inner.js` (`scoringDimensions`) match those listed in both documents
- [ ] Verify Docker port mappings match `docker-compose.yml`
- [ ] Verify T3 redaction section accurately reflects `export.js` and `redactT3Items()` in `inner.js`
- [ ] Check both documents render correctly on GitHub
