### PR TITLE
fix: copy file-saver dist artifacts to component root

### DIFF
--- a/scripts/copy-components.js
+++ b/scripts/copy-components.js
@@ -92,3 +92,15 @@ if (Fs.existsSync(scryptMin)) {
         Fs.writeFileSync(scryptMin, scryptContent, 'utf8');
     }
 }
+
+// file-saver 2.x ships build artifacts under dist/; CryptPad expects them at
+// the component root (/components/file-saver/FileSaver.min.js).
+var fileSaverDist = Path.join(componentsPath, "file-saver", "dist");
+if (Fs.existsSync(fileSaverDist)) {
+    for (const f of Fs.readdirSync(fileSaverDist)) {
+        Fs.copyFileSync(
+            Path.join(fileSaverDist, f),
+            Path.join(componentsPath, "file-saver", f)
+        );
+    }
+}


### PR DESCRIPTION
## Summary

- `file-saver` 2.x ships `FileSaver.min.js` under `dist/` — the copy-components script copied the full package directory, leaving the file at `www/components/file-saver/dist/FileSaver.min.js`
- CryptPad's client code (`sframe-common-file.js`, `common-mediatag.js`) requests `/components/file-saver/FileSaver.min.js` (no `dist/` prefix)
- This caused a RequireJS `Script Error` on every page load, breaking the Drive and all apps

**Fix:** Added a post-copy step in `scripts/copy-components.js` that flattens `file-saver/dist/` contents into the component root, matching the expected URL path.

## Root cause

The `copy-components.js` forEach loop does `Fs.cpSync(source, destination, { recursive: true })` — which faithfully replicates the npm package structure. `file-saver` changed its layout in v2.x to put artifacts under `dist/`. The other components listed in that script all place their browser-ready files at the package root, so only `file-saver` is affected.

## Test plan

- [ ] Rebuild Docker image: `docker compose -f /opt/cryptpad/docker-compose.yml build`
- [ ] Verify `www/components/file-saver/FileSaver.min.js` exists at root (not only in `dist/`)
- [ ] Load CryptPad in browser — no RequireJS Script Error in console
- [ ] Drive and Kanban apps open without JS errors

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Chores**
  * Updated build process to optimize component distribution handling.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->