### PR TITLE
fix(ci): add concurrency group to prevent concurrent deploy collisions

### DIFF
--- a/.github/workflows/deploy.yml
+++ b/.github/workflows/deploy.yml
@@ -8,7 +8,7 @@ on:
 
 concurrency:
   group: production-deploy
-  cancel-in-progress: true
+  cancel-in-progress: false
 
 permissions:
   contents: read

--- a/.github/workflows/deploy.yml
+++ b/.github/workflows/deploy.yml
@@ -6,6 +6,10 @@ on:
       - main
   workflow_dispatch:
 
+concurrency:
+  group: production-deploy
+  cancel-in-progress: true
+
 permissions:
   contents: read
 


### PR DESCRIPTION
## Problem

Two PRs (#99 and #94) were merged 2 seconds apart, triggering simultaneous deploy jobs. Both jobs SSHed into the production server at the same time and collided on `docker compose down/up`, causing:

```
Error response from daemon: removal of container ... is already in progress
```

The server survived because one of the two jobs completed first, but the second job failed with exit code 1 — which means any future pair of near-simultaneous merges will hit the same failure.

## Fix

Add a `concurrency` group at the workflow level:

```yaml
concurrency:
  group: production-deploy
  cancel-in-progress: true
```

With this in place: if a second deploy is triggered while one is already running, GitHub cancels the in-progress job before it reaches the SSH step. The newer job then runs alone with the latest code. No two jobs can ever touch the server simultaneously.

## Why `cancel-in-progress: true`

The alternative (`cancel-in-progress: false`) would queue the second job and run both sequentially. That's worse: the first job deploys stale code, then the second job deploys again minutes later — double the downtime. With `cancel-in-progress: true`, only one deploy runs and it always deploys the latest commit.


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **Chores**
  * Updated deployment workflow to group concurrent deploy runs without canceling in-progress executions.
  * Fixed deployment log output by ensuring the completion message ends with a newline.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->