### PR TITLE
fix(ci): pin tree-sitter-language-pack<1.8 for desloppify gate

### DIFF
--- a/.github/workflows/desloppify.yml
+++ b/.github/workflows/desloppify.yml
@@ -36,12 +36,29 @@ jobs:
           git clone --no-recurse-submodules https://github.com/Open-Paws/desloppify.git /tmp/desloppify
 
       - name: Install desloppify
-        run: pip install "/tmp/desloppify[full]"
+        run: |
+          # Pin tree-sitter-language-pack to <1.8 — the 1.8.0 release (after
+          # 2026-05-02) changed the type of objects it returns, producing
+          # `TypeError: __new__() argument 1 must be tree_sitter.Language,
+          # not builtins.Language` inside desloppify's tree-sitter analysis.
+          # This broke the quality gate on every PR opened after the
+          # language-pack 1.8.0 release, including dependabot PRs #115-#119.
+          # Drop the constraint once desloppify (or language-pack) ships a
+          # compatible fix and this workflow has been verified against it.
+          pip install "tree-sitter-language-pack<1.8"
+          pip install "/tmp/desloppify[full]"
 
       - name: Run quality gate
         run: |
+          set +e
           SCAN_OUTPUT=$(desloppify scan --path . --profile ci --no-badge 2>&1)
+          SCAN_RC=$?
+          set -e
           echo "${SCAN_OUTPUT}"
+          if [ "${SCAN_RC}" -ne 0 ]; then
+            echo "ERROR: desloppify scan exited with code ${SCAN_RC}"
+            exit 1
+          fi
           SCORE=$(echo "${SCAN_OUTPUT}" | grep -oP 'objective \K[\d.]+(?=/100)')
           if [ -z "${SCORE}" ]; then
             echo "ERROR: could not extract objective score from desloppify output"


### PR DESCRIPTION
## Root cause

[tree-sitter-language-pack 1.8.0](https://pypi.org/project/tree-sitter-language-pack/) was released between the 5/02 passing dependabot wave and the 5/09 failing wave. The 1.8.0 release changed the type of objects returned by its language loader. desloppify's tree-sitter analysis still expects the prior type, so the scan crashes with:

```
TypeError: __new__() argument 1 must be tree_sitter.Language, not builtins.Language
```

The scan was wrapped in `\$(...)` under `bash -e`, so the error was swallowed by the command substitution and never surfaced in the run logs — the failure was completely opaque on [run 25614399584](https://github.com/Open-Paws/cryptpad-project-management/actions/runs/25614399584/job/75189821124) and the other four. This is not a dependabot-context issue at all — the passing 5/02 runs ran under the same `Secret source: Dependabot` and `Contents: read` permissions.

Confirmed by comparing pip-installed packages between passing and failing runs:
- 5/02 passing: `tree-sitter-language-pack-1.6.3`
- 5/09+ failing: `tree-sitter-language-pack-1.8.0`

The desloppify upstream commit [99b44426](https://github.com/Open-Paws/desloppify/commit/99b44426f256b7e6f9120b2319641f40f4fbe844) (2026-05-03, \"API Veracity gate\") was an initial suspect but is unrelated — pinning desloppify to the prior revision still failed with the same TypeError, confirming the regression is in the transitive Python dep.

## Fix

- `pip install \"tree-sitter-language-pack<1.8\"` before the desloppify install, so pip's resolver locks language-pack to the same 1.x line that worked on 5/02 regardless of what version main resolves to today.
- Capture the scan exit code with `set +e` around the subshell capture and surface it explicitly, so the next upstream regression doesn't fail silently inside `\$(...)`. This is the change that made today's diagnosis possible at all.

Smallest viable diff. No threshold lowering. No removing the check from required-checks.

## Test plan

- [x] YAML validates
- [ ] This PR's own Desloppify Quality Gate check runs green
- [ ] After merge, re-trigger CI on #115-#119 (close+reopen or `@dependabot rebase`) so they pick up the fixed workflow and the gate goes green
- [ ] Drop the `<1.8` constraint once desloppify or language-pack ships a compatible fix and the workflow has been re-verified

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Chores**
  * Pinned a tool version used in the quality gate to prevent upstream breakages and ensure consistent installs.
  * Improved quality gate failure handling: captures and prints full scan output, makes scan failures explicit, and hard-fails the job when scans exit non‑zero while preserving the existing score threshold check.

[![Review Change Stack](https://storage.googleapis.com/coderabbit_public_assets/review-stack-in-coderabbit-ui.svg)](https://app.coderabbit.ai/change-stack/Open-Paws/cryptpad-project-management/pull/120)

[![Review Change Stack](https://storage.googleapis.com/coderabbit_public_assets/review-stack-in-coderabbit-ui.svg)](https://app.coderabbit.ai/change-stack/Open-Paws/cryptpad-project-management/pull/120)

<!-- end of auto-generated comment: release notes by coderabbit.ai -->