### PR TITLE
fix(deps): revert http-proxy-middleware v4 + ignore future major bumps

### DIFF
--- a/.github/dependabot.yml
+++ b/.github/dependabot.yml
@@ -8,3 +8,9 @@ updates:
     directory: "/"
     schedule:
       interval: "weekly"
+    ignore:
+      # http-proxy-middleware v4+ is ESM-only and requires Node ^22.15.0,
+      # but this repo's engines.node is >=18 and lib/http-worker.js uses
+      # CommonJS require(). v3.x patches/minors continue to flow.
+      - dependency-name: "http-proxy-middleware"
+        update-types: ["version-update:semver-major"]

--- a/package-lock.json
+++ b/package-lock.json
@@ -34,7 +34,7 @@
         "fs-extra": "^11.3.4",
         "get-folder-size": "^5.0.0",
         "html2canvas": "^1.4.0",
-        "http-proxy-middleware": "^4.0.0",
+        "http-proxy-middleware": "^3.0.3",
         "hyper-json": "~1.5.0",
         "jquery": "4.0.0",
         "json.sortify": "github:cryptpad/JSON.sortify",
@@ -1296,6 +1296,15 @@
       "integrity": "sha512-dWHzHa2WqEXI/O1E9OjrocMTKJl2mSrEolh1Iomrv6U+JuNwaHXsXx9bLu5gG7BUWFIN0skIQJQ/L1rIex4X6w==",
       "dev": true,
       "license": "MIT"
+    },
+    "node_modules/@types/http-proxy": {
+      "version": "1.17.16",
+      "resolved": "https://registry.npmjs.org/@types/http-proxy/-/http-proxy-1.17.16.tgz",
+      "integrity": "sha512-sdWoUajOB1cd0A8cRRQ1cfyWNbmFKLAqBB89Y8x5iYyG/mkJHc0YUH8pdWBy2omi9qtCpiIgGjuwO0dQST2l5w==",
+      "license": "MIT",
+      "dependencies": {
+        "@types/node": "*"
+      }
     },
     "node_modules/@types/json-schema": {
       "version": "7.0.15",
@@ -3167,6 +3176,12 @@
         "node": ">= 0.6"
       }
     },
+    "node_modules/eventemitter3": {
+      "version": "4.0.7",
+      "resolved": "https://registry.npmjs.org/eventemitter3/-/eventemitter3-4.0.7.tgz",
+      "integrity": "sha512-8guHBZCwKnFhYdHr2ysuRWErTwhoN2X8XELRlrRwpmfeY2jjuUN4taQMsULKUVo1K4DvZl+0pgfyoysHxvmvEw==",
+      "license": "MIT"
+    },
     "node_modules/express": {
       "version": "5.2.1",
       "resolved": "https://registry.npmjs.org/express/-/express-5.2.1.tgz",
@@ -3429,6 +3444,26 @@
       "integrity": "sha512-GX+ysw4PBCz0PzosHDepZGANEuFCMLrnRTiEy9McGjmkCQYwRq4A/X786G/fjM/+OjsWSU1ZrY5qyARZmO/uwg==",
       "dev": true,
       "license": "ISC"
+    },
+    "node_modules/follow-redirects": {
+      "version": "1.15.9",
+      "resolved": "https://registry.npmjs.org/follow-redirects/-/follow-redirects-1.15.9.tgz",
+      "integrity": "sha512-gew4GsXizNgdoRyqmyfMHyAmXsZDk6mHkSxZFCzW9gwlbtOW44CDtYavM+y+72qD/Vq2l550kMF52DT8fOLJqQ==",
+      "funding": [
+        {
+          "type": "individual",
+          "url": "https://github.com/sponsors/RubenVerborgh"
+        }
+      ],
+      "license": "MIT",
+      "engines": {
+        "node": ">=4.0"
+      },
+      "peerDependenciesMeta": {
+        "debug": {
+          "optional": true
+        }
+      }
     },
     "node_modules/for-in": {
       "version": "1.0.2",
@@ -3882,27 +3917,36 @@
         "url": "https://opencollective.com/express"
       }
     },
-    "node_modules/http-proxy-middleware": {
-      "version": "4.0.0",
-      "resolved": "https://registry.npmjs.org/http-proxy-middleware/-/http-proxy-middleware-4.0.0.tgz",
-      "integrity": "sha512-wuHwaUtmC0XzJNHqRp41zXtt5ojpHbusXGhq6781VvnjWUYPu7opmOF3eomGNujT07kEOnHWZyV9UZzKimVCKA==",
+    "node_modules/http-proxy": {
+      "version": "1.18.1",
+      "resolved": "https://registry.npmjs.org/http-proxy/-/http-proxy-1.18.1.tgz",
+      "integrity": "sha512-7mz/721AbnJwIVbnaSv1Cz3Am0ZLT/UBwkC92VlxhXv/k/BBQfM2fXElQNC27BVGr0uwUpplYPQM9LnaBMR5NQ==",
       "license": "MIT",
       "dependencies": {
-        "debug": "^4.4.3",
-        "httpxy": "^0.5.1",
+        "eventemitter3": "^4.0.0",
+        "follow-redirects": "^1.0.0",
+        "requires-port": "^1.0.0"
+      },
+      "engines": {
+        "node": ">=8.0.0"
+      }
+    },
+    "node_modules/http-proxy-middleware": {
+      "version": "3.0.5",
+      "resolved": "https://registry.npmjs.org/http-proxy-middleware/-/http-proxy-middleware-3.0.5.tgz",
+      "integrity": "sha512-GLZZm1X38BPY4lkXA01jhwxvDoOkkXqjgVyUzVxiEK4iuRu03PZoYHhHRwxnfhQMDuaxi3vVri0YgSro/1oWqg==",
+      "license": "MIT",
+      "dependencies": {
+        "@types/http-proxy": "^1.17.15",
+        "debug": "^4.3.6",
+        "http-proxy": "^1.18.1",
         "is-glob": "^4.0.3",
-        "is-plain-obj": "^4.1.0",
+        "is-plain-object": "^5.0.0",
         "micromatch": "^4.0.8"
       },
       "engines": {
-        "node": "^22.15.0 || ^24.0.0 || >=26.0.0"
+        "node": "^14.15.0 || ^16.10.0 || >=18.0.0"
       }
-    },
-    "node_modules/httpxy": {
-      "version": "0.5.1",
-      "resolved": "https://registry.npmjs.org/httpxy/-/httpxy-0.5.1.tgz",
-      "integrity": "sha512-JPhqYiixe1A1I+MXDewWDZqeudBGU8Q9jCHYN8ML+779RQzLjTi78HBvWz4jMxUD6h2/vUL12g4q/mFM0OUw1A==",
-      "license": "MIT"
     },
     "node_modules/hyper-json": {
       "version": "1.5.0",
@@ -4159,23 +4203,10 @@
         "url": "https://github.com/sponsors/sindresorhus"
       }
     },
-    "node_modules/is-plain-obj": {
-      "version": "4.1.0",
-      "resolved": "https://registry.npmjs.org/is-plain-obj/-/is-plain-obj-4.1.0.tgz",
-      "integrity": "sha512-+Pgi+vMuUNkJyExiMBt5IlFoMyKnr5zhJ4Uspz58WOhBF5QoIZkFyNHIbBAtHwzVAgk5RtndVNsDRN61/mmDqg==",
-      "license": "MIT",
-      "engines": {
-        "node": ">=12"
-      },
-      "funding": {
-        "url": "https://github.com/sponsors/sindresorhus"
-      }
-    },
     "node_modules/is-plain-object": {
       "version": "5.0.0",
       "resolved": "https://registry.npmjs.org/is-plain-object/-/is-plain-object-5.0.0.tgz",
       "integrity": "sha512-VRSzKkbMm5jMDoKLbltAkFQ5Qr7VDiTFGXxYFXXowVj387GeGNOCsOH6Msy00SGZ3Fp84b1Naa1psqgcCIEP5Q==",
-      "dev": true,
       "license": "MIT",
       "engines": {
         "node": ">=0.10.0"
@@ -6094,6 +6125,12 @@
       "resolved": "https://registry.npmjs.org/requirejs-plugins/-/requirejs-plugins-1.0.2.tgz",
       "integrity": "sha512-bX1vGnjDd1iIod3hst47oM/Nv9JiYw4qodWNKgyeQw5ahzSvPI3j1K6hMcK0HtiGRKxebCf+QUrtWzbrZtzQog==",
       "license": "ISC"
+    },
+    "node_modules/requires-port": {
+      "version": "1.0.0",
+      "resolved": "https://registry.npmjs.org/requires-port/-/requires-port-1.0.0.tgz",
+      "integrity": "sha512-KigOCHcocU3XODJxsu8i/j8T9tzT4adHiecwORRQ0ZZFcp7ahwXuRU1m+yuO90C5ZUyGeGfocHDI14M3L3yDAQ==",
+      "license": "MIT"
     },
     "node_modules/resolve": {
       "version": "1.22.10",

--- a/package.json
+++ b/package.json
@@ -43,7 +43,7 @@
     "fs-extra": "^11.3.4",
     "get-folder-size": "^5.0.0",
     "html2canvas": "^1.4.0",
-    "http-proxy-middleware": "^4.0.0",
+    "http-proxy-middleware": "^3.0.3",
     "hyper-json": "~1.5.0",
     "jquery": "4.0.0",
     "json.sortify": "github:cryptpad/JSON.sortify",


### PR DESCRIPTION
Reverts the http-proxy-middleware v3 -> v4 bump (PR #117, SHA `0930f93`, merged earlier today via auto-merge) and prevents reintroduction.

- Reverts commit `0930f93aae1d0cd7ac01fb73cda155f82b69687c` — restores `package.json` to `http-proxy-middleware: ^3.0.3` and `package-lock.json` to `3.0.5`.
- Root cause: http-proxy-middleware v4 is ESM-only (`type:module`, only `exports.import`, no CJS path) and declares `engines.node ^22.15.0 || ^24.0.0 || >=26.0.0`. This repo declares `engines.node >=18` and `lib/http-worker.js` loads the module via `const { createProxyMiddleware } = require(http-proxy-middleware)`. Result: `ERR_REQUIRE_ESM`-class crash at http worker startup. Hard production failure on any in-support Node 18/20 deployment.
- Adds a dependabot ignore on `version-update:semver-major` for `http-proxy-middleware` so v4+ does not get re-proposed. v3.x patches and minors continue to flow.

## Test plan

- [ ] `package.json` matches pre-#117 state: `http-proxy-middleware: ^3.0.3`
- [ ] `package-lock.json` matches pre-#117 state: resolved at `3.0.5`
- [ ] `.github/dependabot.yml` ignores `http-proxy-middleware` semver-major
- [ ] Required CI checks green (Desloppify gate is informational per org ruleset, not required)
- [ ] Manual smoke: `node -e require('http-proxy-middleware')` succeeds on Node 18/20

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Chores**
  * Updated dependency management configuration to prevent major version updates and adjusted a dependency version constraint to maintain stability.

[![Review Change Stack](https://storage.googleapis.com/coderabbit_public_assets/review-stack-in-coderabbit-ui.svg)](https://app.coderabbit.ai/change-stack/Open-Paws/cryptpad-project-management/pull/121)

<!-- end of auto-generated comment: release notes by coderabbit.ai -->